### PR TITLE
Ligatures no ruby

### DIFF
--- a/reader/en.json
+++ b/reader/en.json
@@ -214,7 +214,7 @@
                 "title": "Line height"
             },
             "noRuby": {
-                "label": "Disable ruby annotations",
+                "label": "Hide ruby annotations",
                 "title": "Ruby annotations"
             },
             "offsetFirstPage": "Display first page on its own",

--- a/reader/en.json
+++ b/reader/en.json
@@ -202,12 +202,20 @@
                 "title": "Layout"
             },
             "letterSpacing": "Letter spacing",
+            "ligatures": {
+                "label": "Enable ligatures",
+                "title": "Ligatures"
+            },
             "lineHeight": {
                 "default": "Default",
                 "large": "Loose",
                 "medium": "Balanced",
                 "small": "Tight",
                 "title": "Line height"
+            },
+            "noRuby": {
+                "label": "Disable ruby annotations",
+                "title": "Ruby annotations"
             },
             "offsetFirstPage": "Display first page on its own",
             "paragraphIndent": "Paragraph indent",


### PR DESCRIPTION
This adds locales for preferences “Ligatures” and `noRuby` in ReadiumCSS. These are toggles as they are flags hence are treated as booleans. 

<img width="1624" height="981" alt="Capture d’écran 2026-04-17 à 10 23 15" src="https://github.com/user-attachments/assets/ecb6ea00-ee12-4de0-932f-d754135262b4" />

<img width="1624" height="981" alt="Capture d’écran 2026-04-17 à 10 23 42" src="https://github.com/user-attachments/assets/0b94bf9c-6f15-4b4f-8f2f-4c94bbc755dc" />

